### PR TITLE
fix: KCEF initialization race breaking WebView-based sources (Comix)

### DIFF
--- a/Mihon.ExtensionsBridge.Net/Android.Compatibility.Layer/AndroidCompat/src/main/java/xyz/nulldev/androidcompat/webkit/KcefWebViewProvider.kt
+++ b/Mihon.ExtensionsBridge.Net/Android.Compatibility.Layer/AndroidCompat/src/main/java/xyz/nulldev/androidcompat/webkit/KcefWebViewProvider.kt
@@ -270,6 +270,48 @@ class KcefWebViewProvider(
             ensureCefApp()
         }
 
+        private const val CEF_INIT_TIMEOUT_MS = 30_000L
+
+        /**
+         * Blocks until CEF's native initialization reaches INITIALIZED, or the timeout expires.
+         *
+         * CefAppBuilder.build() only installs the bundle and creates the CefApp object; the native
+         * initialization is deferred until the first createClient() call and then completes
+         * asynchronously on the AWT EDT. Anything that talks to native CEF before that transition
+         * (notably CefCookieManager.getGlobalManager(), which returns null) fails confusingly, so
+         * the WebView init path waits here between creating its client and running the
+         * InitBrowserHandler. Returns true when CEF is initialized; false (with a loud warning)
+         * on timeout or a terminal state, letting the caller proceed to fail with a clear log
+         * trail instead of an NPE cascade.
+         */
+        fun awaitCefInitialized(timeoutMs: Long = CEF_INIT_TIMEOUT_MS): Boolean {
+            val deadline = System.currentTimeMillis() + timeoutMs
+            while (true) {
+                when (CefApp.getState()) {
+                    CefApp.CefAppState.INITIALIZED -> return true
+                    CefApp.CefAppState.SHUTTING_DOWN, CefApp.CefAppState.TERMINATED -> {
+                        Log.w(TAG, "CEF entered state ${CefApp.getState()} while waiting for initialization")
+                        return false
+                    }
+                    else -> {}
+                }
+                if (System.currentTimeMillis() >= deadline) {
+                    Log.w(
+                        TAG,
+                        "CEF did not reach INITIALIZED within $timeoutMs ms (state=${CefApp.getState()}); " +
+                            "WebView-based sources will likely fail on this run",
+                    )
+                    return false
+                }
+                try {
+                    Thread.sleep(50L)
+                } catch (e: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    return false
+                }
+            }
+        }
+
         private fun CefSettings.trySetBooleanOption(fieldName: String, value: Boolean) {
             val field = runCatching { javaClass.getDeclaredField(fieldName) }.getOrNull()
             if (field == null) {
@@ -1269,6 +1311,9 @@ class KcefWebViewProvider(
 
         cefClient = client
         messageRouter = router
+        // createClient() above is what triggers CEF's deferred native initialization; wait for it
+        // so the init handler (cookie preload) and the first browser never race a half-started CEF.
+        awaitCefInitialized()
         initHandler.init(this)
     }
 

--- a/Mihon.ExtensionsBridge.Net/Android.Compatibility.Layer/AndroidCompat/src/main/kotlin/extension/bridge/Startup.kt
+++ b/Mihon.ExtensionsBridge.Net/Android.Compatibility.Layer/AndroidCompat/src/main/kotlin/extension/bridge/Startup.kt
@@ -312,7 +312,14 @@ fun applicationSetup(dataRoot: String, tempRoot: String, sink: AndroidCompatLogS
                             val networkHelper = Injekt.get<NetworkHelper>()
                             val logger = androidCompatLogger(KcefWebViewProvider::class.java)
                             logger.debug { "Start loading cookies" }
-                            CefCookieManager.getGlobalManager().apply {
+                            // getGlobalManager() returns null until CEF's native initialization
+                            // completes; a null receiver here used to NPE on every setCookie call.
+                            val manager: CefCookieManager? = CefCookieManager.getGlobalManager()
+                            if (manager == null) {
+                                logger.warn { "CEF global cookie manager unavailable (CEF not initialized); skipping stored-cookie preload" }
+                                return
+                            }
+                            manager.apply {
                                 val cookies = networkHelper.cookieStore.getStoredCookies()
                                 for (cookie in cookies) {
                                     try {

--- a/Mihon.ExtensionsBridge.Net/libs/Android.Compat.dll
+++ b/Mihon.ExtensionsBridge.Net/libs/Android.Compat.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82a5e087b4b430a1ea1d9a5ce2964b19615051a96f9a2a51bc47273c2492cdf2
-size 207117824
+oid sha256:8bdfda48f9b90fb5460df460a3d1f157940c5f2903452804c7e7aeb5c2e7eb76
+size 207102464

--- a/Mihon.ExtensionsBridge.Net/libs/Android.Compat.dll
+++ b/Mihon.ExtensionsBridge.Net/libs/Android.Compat.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:95dbd5bb4c0d33a65b64a25cf9e969efee4b43d25624139b712eccd1e29471ce
-size 207098368
+oid sha256:82a5e087b4b430a1ea1d9a5ce2964b19615051a96f9a2a51bc47273c2492cdf2
+size 207117824


### PR DESCRIPTION
## Problem

Reported by Jtecx: Comix searches/updates fail with `Failed to start WebView` / `Timed out waiting for WebView payload`, preceded by an NPE stack per stored cookie from `KcefWebViewProvider` (`Loading cookie X failed — NullPointerException at Startup.kt:319`).

`CefAppBuilder.build()` only installs the JCEF bundle and creates the CefApp object — CEF's **native initialization is deferred until the first `createClient()`** and then completes asynchronously on the AWT EDT. The WebView init path ran the `InitBrowserHandler` (stored-cookie preload) immediately after `createClient`, racing that startup: `CefCookieManager.getGlobalManager()` returns **null** until CEF reaches INITIALIZED (a Kotlin extension receiver on a null platform type defers the NPE to the first member call — hence one NPE per cookie), and the first browser navigation raced the same half-started engine. Fast machines usually win the race; Jtecx's box never did.

## Fix

- **KcefWebViewProvider**: new `awaitCefInitialized()` helper polls `CefApp.getState()` (30s ceiling, loud warning naming the state on timeout/terminal state). `init()` calls it between `createClient()` and the `InitBrowserHandler`, so the cookie preload and the first browser never run against a half-started CEF.
- **Startup**: the cookie preload null-guards the global cookie manager and skips with a single clear warning instead of an NPE cascade — a genuinely failed CEF init now reads as exactly that in the log.

Rebuilt `Android.Compat.dll` included.

Heads-up: `AndroidCompat.Build.ps1` fails under PowerShell 7 (`Cannot overwrite variable IsWindows` — it's a read-only automatic variable there); built via Windows PowerShell 5.1.

## Validation

- Non-WebView regression clean: extension install, dex2jar conversion, popular/details fetches all pass through the rebuilt dll (Internal.Tests harness).
- The WebView path itself can't be exercised on Windows (known IKVM/CEF FailFast after WebView use); live verification lands on Jtecx's Docker retest with the next test image.