### PR TITLE
fix: surface augment failures in the add-series wizard instead of silently doing nothing

### DIFF
--- a/RensaioBackend/Models/Dto/AugmentSourceErrorDto.cs
+++ b/RensaioBackend/Models/Dto/AugmentSourceErrorDto.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace RensaioBackend.Models.Dto
+{
+    /// <summary>
+    /// Describes why a selected source could not contribute series details during augmentation.
+    /// </summary>
+    public class AugmentSourceErrorDto
+    {
+        [JsonPropertyName("provider")]
+        public string Provider { get; set; } = string.Empty;
+
+        [JsonPropertyName("title")]
+        public string Title { get; set; } = string.Empty;
+
+        [JsonPropertyName("reason")]
+        public string Reason { get; set; } = string.Empty;
+    }
+}

--- a/RensaioBackend/Models/Dto/AugmentedResponseDto.cs
+++ b/RensaioBackend/Models/Dto/AugmentedResponseDto.cs
@@ -35,6 +35,9 @@ namespace RensaioBackend.Models.Dto
         [JsonPropertyName("startChapter")]
         public decimal? StartChapter { get; set; } = null;
 
+        [JsonPropertyName("sourceErrors")]
+        public List<AugmentSourceErrorDto> SourceErrors { get; set; } = [];
+
         [JsonIgnore] 
         public ImportSeriesSnapshot LocalInfo { get; set; } = new ImportSeriesSnapshot();
         [JsonIgnore]

--- a/RensaioBackend/Services/Search/SearchCommandService.cs
+++ b/RensaioBackend/Services/Search/SearchCommandService.cs
@@ -67,7 +67,12 @@ namespace RensaioBackend.Services.Search
 
                 // Fetch full series data in parallel
                 var seriesDetailsMap = new ConcurrentDictionary<string, (ParsedManga, List<ParsedChapter>)>();
+                var sourceErrors = new ConcurrentBag<AugmentSourceErrorDto>();
                 var validSeries = linkedSeries.Where(ls => !string.IsNullOrEmpty(ls.MihonId)).ToList();
+                foreach (var ls in linkedSeries.Where(ls => string.IsNullOrEmpty(ls.MihonId)))
+                {
+                    sourceErrors.Add(new AugmentSourceErrorDto { Provider = ls.Provider, Title = ls.Title, Reason = "Source is not installed or unavailable." });
+                }
                 var maxConcurrency = Math.Min(appSettings.NumberOfSimultaneousSearches, validSeries.Count);
                 var parallelOptions = new ParallelOptions
                 {
@@ -97,6 +102,12 @@ namespace RensaioBackend.Services.Search
                             });
                             seriesDetailsMap.TryAdd(ls.MihonId!, (fullData, chapterData));
                         }
+                        else
+                        {
+                            var reason = fullData == null ? "Source returned no details for this series." : "Source has no readable chapters for this series.";
+                            _logger.LogWarning("Skipping {Title} from {Provider}: {Reason}", ls.Title, ls.Provider, reason);
+                            sourceErrors.Add(new AugmentSourceErrorDto { Provider = ls.Provider, Title = ls.Title, Reason = reason });
+                        }
                     }
                     catch (OperationCanceledException) when (ct.IsCancellationRequested)
                     {
@@ -105,14 +116,17 @@ namespace RensaioBackend.Services.Search
                     catch (TimeoutException)
                     {
                         _logger.LogWarning("Fetching details for {Title} from {Provider} timed out after {Seconds}s; skipping.", ls.Title, ls.Provider, SourceTimeout.DefaultTimeout.TotalSeconds);
+                        sourceErrors.Add(new AugmentSourceErrorDto { Provider = ls.Provider, Title = ls.Title, Reason = $"Timed out after {SourceTimeout.DefaultTimeout.TotalSeconds:0}s." });
                     }
                     catch (HttpRequestException r)
                     {
-                        _logger.LogWarning("Error fetching series details for {Title} from {Provider}: Http Error {StatusCode}.", ls.Title, ls.Provider, r.StatusCode);
+                        _logger.LogWarning("Error fetching series details for {Title} from {Provider}: Http Error {StatusCode}. {Message}", ls.Title, ls.Provider, r.StatusCode, r.Message);
+                        sourceErrors.Add(new AugmentSourceErrorDto { Provider = ls.Provider, Title = ls.Title, Reason = r.StatusCode != null ? $"HTTP error {(int)r.StatusCode} ({r.StatusCode})." : $"Connection error: {r.Message}" });
                     }
                     catch (Exception ex)
                     {
                         _logger.LogError(ex, "Error fetching details for series ID {Title}: {Message}", ls.Title, ex.Message);
+                        sourceErrors.Add(new AugmentSourceErrorDto { Provider = ls.Provider, Title = ls.Title, Reason = ex.Message });
                     }
                 }).ConfigureAwait(false);
 
@@ -209,6 +223,7 @@ namespace RensaioBackend.Services.Search
                 return new AugmentedResponseDto
                 {
                     Series = ProviderSeriesDetailsResults,
+                    SourceErrors = sourceErrors.ToList(),
                     StorageFolderPath = appSettings.StorageFolder,
                     UseCategoriesForPath = appSettings.CategorizedFolders,
                     Categories = appSettings.Categories?.ToList() ?? [],
@@ -219,7 +234,10 @@ namespace RensaioBackend.Services.Search
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error in AugmentSeriesAsync: {Message}", ex.Message);
-                return new AugmentedResponseDto();
+                return new AugmentedResponseDto
+                {
+                    SourceErrors = [new AugmentSourceErrorDto { Reason = $"Unexpected error while fetching series details: {ex.Message}" }]
+                };
             }
         }
     }

--- a/RensaioFrontend/src/components/comp/series/add-series/steps/index.tsx
+++ b/RensaioFrontend/src/components/comp/series/add-series/steps/index.tsx
@@ -14,7 +14,7 @@ import { useAddSeries } from "@/lib/api/hooks/useSeries";
 import { useAugmentSeries } from "@/lib/api/hooks/useSearch";
 import { useToast } from "@/hooks/use-toast";
 import { useQueryClient } from "@tanstack/react-query";
-import { type LinkedSeries, type FullSeries, type ExistingSource, type AugmentedResponse } from "@/lib/api/types";
+import { type LinkedSeries, type FullSeries, type ExistingSource, type AugmentedResponse, type AugmentSourceError } from "@/lib/api/types";
 
 /** Find the first series whose language matches the user's preferred languages. */
 function findPreferredSeriesIndex(series: FullSeries[], preferredLanguages: string[] | undefined | null): number {
@@ -108,13 +108,36 @@ export function AddSeriesSteps({
     }
   };
 
+  const formatSourceErrors = (errors: AugmentSourceError[]): string =>
+    errors
+      .map((e) => (e.provider ? `${e.provider}: ${e.reason}` : e.reason))
+      .join(" ");
+
   const handleNext = async () => {
+    setError(null);
     try {
       const allLinkedSeries = formState.allLinkedSeries;
       const selectedLinked: LinkedSeries[] = allLinkedSeries.filter((series: LinkedSeries) =>
         formState.selectedLinkedSeries.includes(series.mihonId ?? series.providerId)
       );
       const augmentedResponse = await augmentSeries.mutateAsync(selectedLinked);
+
+      const sourceErrors = augmentedResponse.sourceErrors ?? [];
+      if (!augmentedResponse.series || augmentedResponse.series.length === 0) {
+        const detail = sourceErrors.length > 0
+          ? formatSourceErrors(sourceErrors)
+          : "None of the selected sources returned any details.";
+        setError(detail);
+        toast({ title: "Couldn't fetch series details", description: detail, variant: "destructive" });
+        return;
+      }
+      if (sourceErrors.length > 0) {
+        toast({
+          title: "Some sources were skipped",
+          description: formatSourceErrors(sourceErrors),
+          variant: "destructive",
+        });
+      }
 
       if (isAddSourcesMode && seriesId) {
         augmentedResponse.existingSeries = true;
@@ -138,6 +161,9 @@ export function AddSeriesSteps({
       setPendingNextStep(true);
     } catch (err) {
       console.error('Failed to augment series:', err);
+      const msg = err instanceof Error ? err.message : 'Failed to fetch series details.';
+      setError(msg);
+      toast({ title: 'Failed to fetch series details', description: msg, variant: 'destructive' });
     }
   };
 

--- a/RensaioFrontend/src/lib/api/types.ts
+++ b/RensaioFrontend/src/lib/api/types.ts
@@ -182,6 +182,12 @@ export enum InLibraryStatus {
   InLibraryButDisabled = 2,
 }
 
+export interface AugmentSourceError {
+  provider: string;
+  title: string;
+  reason: string;
+}
+
 export interface AugmentedResponse {
   storageFolderPath: string;
   useCategoriesForPath: boolean;
@@ -192,6 +198,7 @@ export interface AugmentedResponse {
   preferredLanguages: string[];
   disableJobs?: boolean;
   startChapter?: number;
+  sourceErrors?: AugmentSourceError[];
 }
 export interface ExistingSource {
   provider: string;


### PR DESCRIPTION
## Problem

Reported by Jtecx: selecting search results in the add-series wizard and clicking **Next** sometimes does absolutely nothing — no error, no spinner outcome, no log line.

Root cause is a fully silent failure chain:

- `SearchCommandService.AugmentSeriesAsync` catches every per-source details/chapters fetch failure, and its outer catch collapses any error into an **empty 200 response**.
- Sources that fetch fine but return **zero readable chapters** (e.g. licensed MangaDex titles) are dropped with no log line at all.
- The frontend only advances to Stage 02 when the augment result is non-empty; with an empty result it sets a pending flag that never fires, and its catch only writes to the browser console.

Net effect: if every selected source fails (or has no chapters), Next silently no-ops forever.

## Fix

**Backend** — `AugmentSeriesAsync` records why each selected source was skipped (not installed, timeout, HTTP error incl. status, no details, no readable chapters, unexpected error) and returns them in a new `sourceErrors` field on `AugmentedResponseDto`. The zero-chapter skip is now also logged.

**Frontend** — the wizard:
- shows the per-source reasons in the existing error banner + a destructive toast when *nothing* could be fetched, staying on the search step;
- warns via toast when only *some* selected sources were skipped (previously they vanished silently);
- surfaces augment request failures (setError + toast) instead of console-only logging.

## Verification

Verified live in the running app (dev mode):
- MangaDex-only selection of a title with 0 readable chapters → banner "MangaDex: Source has no readable chapters for this series." shown in the dialog, stays on Stage 01 (previously: silent no-op).
- Kun Manga + MangaDex selection → advances to Stage 02 with Kun Manga's 29 chapters, skip toast for MangaDex.
- Backend builds clean; frontend typecheck clean for the touched files (scrobbler TS errors pre-existing on main).